### PR TITLE
Added support for AWS and specifying returnUri as config

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,8 +9,9 @@ const useUrlEncodedForm = process.env.REACT_USE_URLENCODEDFORM || true
 
 const {AuthContext, Authenticated, useToken} = createAuthContext({
   clientId,
+  clientSecret,
   provider,
-  scopes : ['email'],
+  // tokenEndpoint: 'http://localhost:3020/token' // If token endpoint is not "provider + '/token'"
   redirectUri,
   useUrlEncodedForm
 })

--- a/src/App.js
+++ b/src/App.js
@@ -4,12 +4,15 @@ import createAuthContext from './lib/createAuthContext'
 const clientId = process.env.REACT_APP_CLIENT_ID || "8cb4904ae5581ecc2b3a1774"
 const clientSecret = process.env.REACT_APP_CLIENT_SECRET || "b683283462070edbac15a8fdab751ada0f501ab48a5f06aa20aee3be24eac9cc"
 const provider = process.env.REACT_APP_PROVIDER || "https://authenticate.u5auth.com"
+const redirectUri = process.env.REACT_RETURN_URI || "https://localhost"
+const useUrlEncodedForm = process.env.REACT_USE_URLENCODEDFORM || true
 
 const {AuthContext, Authenticated, useToken} = createAuthContext({
   clientId,
-  clientSecret,
   provider,
-  // tokenEndpoint: 'http://localhost:3020/token' // If token endpoint is not "provider + '/token'"
+  scopes : ['email'],
+  redirectUri,
+  useUrlEncodedForm
 })
 
 function ProtectedStuff() {

--- a/src/lib/createAuthContext.js
+++ b/src/lib/createAuthContext.js
@@ -1,92 +1,195 @@
-import React, {createContext, useState, useEffect, useContext} from 'react'
-import authorize from './helpers/authorize'
-import { getCodeFromLocation } from './helpers/getCodeFromLocation'
-import { fetchToken } from './helpers/fetchToken'
-import { removeCodeFromLocation } from './helpers/removeCodeFromLocation'
-import { getVerifierFromStorage } from './helpers/getVerifierFromStorage'
-import { removeVerifierFromStorage } from './helpers/removeVerifierFromStorage'
+"use strict";
 
-export default ({
-  clientId,
-  clientSecret,
-  provider,
-  scopes = [],
-  tokenEndpoint = `${provider}/token`,
-  storage = sessionStorage,
-  fetch = window.fetch,
-  busyIndicator = <>logging in...</>
-}) => {
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
 
-  const context = createContext({})
-  const {Provider} = context
+var _react = _interopRequireWildcard(require("react"));
 
-  class Authenticated extends React.Component {
-    static contextType = context
-    componentDidMount() {
-      const { ensureAuthenticated } = this.context
-      ensureAuthenticated()
+var _authorize = _interopRequireDefault(require("./helpers/authorize"));
+
+var _getCodeFromLocation = require("./helpers/getCodeFromLocation");
+
+var _fetchToken = require("./helpers/fetchToken");
+
+var _removeCodeFromLocation = require("./helpers/removeCodeFromLocation");
+
+var _getVerifierFromStorage = require("./helpers/getVerifierFromStorage");
+
+var _removeVerifierFromStorage = require("./helpers/removeVerifierFromStorage");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; if (obj != null) { var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
+
+function _iterableToArrayLimit(arr, i) { if (!(Symbol.iterator in Object(arr) || Object.prototype.toString.call(arr) === "[object Arguments]")) { return; } var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var _default = function _default(_ref) {
+  var clientId = _ref.clientId,
+      clientSecret = _ref.clientSecret,
+      provider = _ref.provider,
+      redirectUri = _ref.redirectUri,
+      useUrlEncodedForm = _ref.useUrlEncodedForm,
+      _ref$scopes = _ref.scopes,
+      scopes = _ref$scopes === void 0 ? [] : _ref$scopes,
+      _ref$tokenEndpoint = _ref.tokenEndpoint,
+      tokenEndpoint = _ref$tokenEndpoint === void 0 ? "".concat(provider, "/token") : _ref$tokenEndpoint,
+      _ref$storage = _ref.storage,
+      storage = _ref$storage === void 0 ? sessionStorage : _ref$storage,
+      _ref$fetch = _ref.fetch,
+      fetch = _ref$fetch === void 0 ? window.fetch : _ref$fetch,
+      _ref$busyIndicator = _ref.busyIndicator,
+      busyIndicator = _ref$busyIndicator === void 0 ? _react.default.createElement(_react.default.Fragment, null, "logging in...") : _ref$busyIndicator;
+  var context = (0, _react.createContext)({});
+  var Provider = context.Provider;
+
+  var Authenticated =
+  /*#__PURE__*/
+  function (_React$Component) {
+    _inherits(Authenticated, _React$Component);
+
+    function Authenticated() {
+      _classCallCheck(this, Authenticated);
+
+      return _possibleConstructorReturn(this, _getPrototypeOf(Authenticated).apply(this, arguments));
     }
-    render() {
-      const { token } = this.context
-      const { children } = this.props
 
-      if (!token) {
-        return busyIndicator
-      } else {
-        return children
+    _createClass(Authenticated, [{
+      key: "componentDidMount",
+      value: function componentDidMount() {
+        var ensureAuthenticated = this.context.ensureAuthenticated;
+        ensureAuthenticated();
       }
-    }
-  }
+    }, {
+      key: "render",
+      value: function render() {
+        var token = this.context.token;
+        var children = this.props.children;
 
-  const useToken = () => {
-    const { token } = useContext(context)
+        if (!token) {
+          return busyIndicator;
+        } else {
+          return children;
+        }
+      }
+    }]);
+
+    return Authenticated;
+  }(_react.default.Component);
+
+  _defineProperty(Authenticated, "contextType", context);
+
+  var useToken = function useToken() {
+    var _useContext = (0, _react.useContext)(context),
+        token = _useContext.token;
+
     if (!token) {
-      console.warn(`Trying to useToken() while not being authenticated.\nMake sure to useToken() only inside of an <Authenticated /> component.`)
+      console.warn("Trying to useToken() while not being authenticated.\nMake sure to useToken() only inside of an <Authenticated /> component.");
     }
-    return token
-  }
+
+    return token;
+  };
 
   return {
-    AuthContext: ({children}) => {
-      const [token, setToken] = useState(null)
+    AuthContext: function AuthContext(_ref2) {
+      var children = _ref2.children;
 
-      // if we have no token, but code and verifier are present,
+      var _useState = (0, _react.useState)(null),
+          _useState2 = _slicedToArray(_useState, 2),
+          token = _useState2[0],
+          setToken = _useState2[1]; // if we have no token, but code and verifier are present,
       // then we try to swap code for token
-      useEffect(() => {
+
+
+      (0, _react.useEffect)(function () {
         if (!token) {
-          const code = getCodeFromLocation({ location: window.location })
-          const verifier = getVerifierFromStorage({ clientId, storage })
+          var code = (0, _getCodeFromLocation.getCodeFromLocation)({
+            location: window.location
+          });
+          var verifier = (0, _getVerifierFromStorage.getVerifierFromStorage)({
+            clientId: clientId,
+            storage: storage
+          });
+
           if (code && verifier) {
-            fetchToken({
-              clientId, clientSecret, tokenEndpoint, code, verifier, fetch
-            })
-            .then(setToken)
-            .then(() => {
-              removeCodeFromLocation()
-              removeVerifierFromStorage({ clientId, storage })  
-            })
-            .catch(e => {
-              console.error(e)
-              alert(`Error fetching auth token: ${e.message}`)
-            })
+            (0, _fetchToken.fetchToken)({
+              clientId: clientId,
+              clientSecret: clientSecret,
+              tokenEndpoint: tokenEndpoint,
+              redirectUri: redirectUri,
+              code: code,
+              verifier: verifier,
+              useUrlEncodedForm: useUrlEncodedForm,
+              fetch: fetch
+            }).then(setToken).then(function () {
+              (0, _removeCodeFromLocation.removeCodeFromLocation)();
+              (0, _removeVerifierFromStorage.removeVerifierFromStorage)({
+                clientId: clientId,
+                storage: storage
+              });
+            }).catch(function (e) {
+              console.error(e);
+              alert("Error fetching auth token: ".concat(e.message));
+            });
           }
         }
-      }, [token])
+      }, [token]);
 
-      const ensureAuthenticated = () => {
-        const code = getCodeFromLocation({ location: window.location })
+      var ensureAuthenticated = function ensureAuthenticated() {
+        var code = (0, _getCodeFromLocation.getCodeFromLocation)({
+          location: window.location
+        });
+
         if (!token && !code) {
-          authorize({provider, clientId, scopes})
+          (0, _authorize.default)({
+            provider: provider,
+            clientId: clientId,
+            scopes: scopes,
+            redirectUri: redirectUri
+          });
         }
-      }
+      };
 
-      return (
-        <Provider value={{token, ensureAuthenticated}}>
-          {children}
-        </Provider>
-      )
+      return _react.default.createElement(Provider, {
+        value: {
+          token: token,
+          ensureAuthenticated: ensureAuthenticated
+        }
+      }, children);
     },
-    Authenticated,
-    useToken
-  }
-}
+    Authenticated: Authenticated,
+    useToken: useToken
+  };
+};
+
+exports.default = _default;
+//# sourceMappingURL=createAuthContext.js.map

--- a/src/lib/createAuthContext.js
+++ b/src/lib/createAuthContext.js
@@ -1,195 +1,94 @@
-"use strict";
+import React, {createContext, useState, useEffect, useContext} from 'react'
+import authorize from './helpers/authorize'
+import { getCodeFromLocation } from './helpers/getCodeFromLocation'
+import { fetchToken } from './helpers/fetchToken'
+import { removeCodeFromLocation } from './helpers/removeCodeFromLocation'
+import { getVerifierFromStorage } from './helpers/getVerifierFromStorage'
+import { removeVerifierFromStorage } from './helpers/removeVerifierFromStorage'
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.default = void 0;
+export default ({
+  clientId,
+  clientSecret,
+  provider,
+  redirectUri,
+  useUrlEncodedForm,
+  scopes = [],
+  tokenEndpoint = `${provider}/token`,
+  storage = sessionStorage,
+  fetch = window.fetch,
+  busyIndicator = <>logging in...</>
+}) => {
 
-var _react = _interopRequireWildcard(require("react"));
+  const context = createContext({})
+  const {Provider} = context
 
-var _authorize = _interopRequireDefault(require("./helpers/authorize"));
-
-var _getCodeFromLocation = require("./helpers/getCodeFromLocation");
-
-var _fetchToken = require("./helpers/fetchToken");
-
-var _removeCodeFromLocation = require("./helpers/removeCodeFromLocation");
-
-var _getVerifierFromStorage = require("./helpers/getVerifierFromStorage");
-
-var _removeVerifierFromStorage = require("./helpers/removeVerifierFromStorage");
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; if (obj != null) { var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
-
-function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
-
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
-
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
-
-function _iterableToArrayLimit(arr, i) { if (!(Symbol.iterator in Object(arr) || Object.prototype.toString.call(arr) === "[object Arguments]")) { return; } var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
-
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
-
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
-
-function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
-
-function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
-
-function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
-var _default = function _default(_ref) {
-  var clientId = _ref.clientId,
-      clientSecret = _ref.clientSecret,
-      provider = _ref.provider,
-      redirectUri = _ref.redirectUri,
-      useUrlEncodedForm = _ref.useUrlEncodedForm,
-      _ref$scopes = _ref.scopes,
-      scopes = _ref$scopes === void 0 ? [] : _ref$scopes,
-      _ref$tokenEndpoint = _ref.tokenEndpoint,
-      tokenEndpoint = _ref$tokenEndpoint === void 0 ? "".concat(provider, "/token") : _ref$tokenEndpoint,
-      _ref$storage = _ref.storage,
-      storage = _ref$storage === void 0 ? sessionStorage : _ref$storage,
-      _ref$fetch = _ref.fetch,
-      fetch = _ref$fetch === void 0 ? window.fetch : _ref$fetch,
-      _ref$busyIndicator = _ref.busyIndicator,
-      busyIndicator = _ref$busyIndicator === void 0 ? _react.default.createElement(_react.default.Fragment, null, "logging in...") : _ref$busyIndicator;
-  var context = (0, _react.createContext)({});
-  var Provider = context.Provider;
-
-  var Authenticated =
-  /*#__PURE__*/
-  function (_React$Component) {
-    _inherits(Authenticated, _React$Component);
-
-    function Authenticated() {
-      _classCallCheck(this, Authenticated);
-
-      return _possibleConstructorReturn(this, _getPrototypeOf(Authenticated).apply(this, arguments));
+  class Authenticated extends React.Component {
+    static contextType = context
+    componentDidMount() {
+      const { ensureAuthenticated } = this.context
+      ensureAuthenticated()
     }
+    render() {
+      const { token } = this.context
+      const { children } = this.props
 
-    _createClass(Authenticated, [{
-      key: "componentDidMount",
-      value: function componentDidMount() {
-        var ensureAuthenticated = this.context.ensureAuthenticated;
-        ensureAuthenticated();
+      if (!token) {
+        return busyIndicator
+      } else {
+        return children
       }
-    }, {
-      key: "render",
-      value: function render() {
-        var token = this.context.token;
-        var children = this.props.children;
+    }
+  }
 
-        if (!token) {
-          return busyIndicator;
-        } else {
-          return children;
-        }
-      }
-    }]);
-
-    return Authenticated;
-  }(_react.default.Component);
-
-  _defineProperty(Authenticated, "contextType", context);
-
-  var useToken = function useToken() {
-    var _useContext = (0, _react.useContext)(context),
-        token = _useContext.token;
-
+  const useToken = () => {
+    const { token } = useContext(context)
     if (!token) {
-      console.warn("Trying to useToken() while not being authenticated.\nMake sure to useToken() only inside of an <Authenticated /> component.");
+      console.warn(`Trying to useToken() while not being authenticated.\nMake sure to useToken() only inside of an <Authenticated /> component.`)
     }
-
-    return token;
-  };
+    return token
+  }
 
   return {
-    AuthContext: function AuthContext(_ref2) {
-      var children = _ref2.children;
+    AuthContext: ({children}) => {
+      const [token, setToken] = useState(null)
 
-      var _useState = (0, _react.useState)(null),
-          _useState2 = _slicedToArray(_useState, 2),
-          token = _useState2[0],
-          setToken = _useState2[1]; // if we have no token, but code and verifier are present,
+      // if we have no token, but code and verifier are present,
       // then we try to swap code for token
-
-
-      (0, _react.useEffect)(function () {
+      useEffect(() => {
         if (!token) {
-          var code = (0, _getCodeFromLocation.getCodeFromLocation)({
-            location: window.location
-          });
-          var verifier = (0, _getVerifierFromStorage.getVerifierFromStorage)({
-            clientId: clientId,
-            storage: storage
-          });
-
+          const code = getCodeFromLocation({ location: window.location })
+          const verifier = getVerifierFromStorage({ clientId, storage })
           if (code && verifier) {
-            (0, _fetchToken.fetchToken)({
-              clientId: clientId,
-              clientSecret: clientSecret,
-              tokenEndpoint: tokenEndpoint,
-              redirectUri: redirectUri,
-              code: code,
-              verifier: verifier,
-              useUrlEncodedForm: useUrlEncodedForm,
-              fetch: fetch
-            }).then(setToken).then(function () {
-              (0, _removeCodeFromLocation.removeCodeFromLocation)();
-              (0, _removeVerifierFromStorage.removeVerifierFromStorage)({
-                clientId: clientId,
-                storage: storage
-              });
-            }).catch(function (e) {
-              console.error(e);
-              alert("Error fetching auth token: ".concat(e.message));
-            });
+            fetchToken({
+              clientId, clientSecret, tokenEndpoint, code, verifier, fetch, redirectUri, useUrlEncodedForm
+            })
+            .then(setToken)
+            .then(() => {
+              removeCodeFromLocation()
+              removeVerifierFromStorage({ clientId, storage })  
+            })
+            .catch(e => {
+              console.error(e)
+              alert(`Error fetching auth token: ${e.message}`)
+            })
           }
         }
-      }, [token]);
+      }, [token])
 
-      var ensureAuthenticated = function ensureAuthenticated() {
-        var code = (0, _getCodeFromLocation.getCodeFromLocation)({
-          location: window.location
-        });
-
+      const ensureAuthenticated = () => {
+        const code = getCodeFromLocation({ location: window.location })
         if (!token && !code) {
-          (0, _authorize.default)({
-            provider: provider,
-            clientId: clientId,
-            scopes: scopes,
-            redirectUri: redirectUri
-          });
+          authorize({provider, clientId, scopes, redirectUri})
         }
-      };
+      }
 
-      return _react.default.createElement(Provider, {
-        value: {
-          token: token,
-          ensureAuthenticated: ensureAuthenticated
-        }
-      }, children);
+      return (
+        <Provider value={{token, ensureAuthenticated}}>
+          {children}
+        </Provider>
+      )
     },
-    Authenticated: Authenticated,
-    useToken: useToken
-  };
-};
-
-exports.default = _default;
-//# sourceMappingURL=createAuthContext.js.map
+    Authenticated,
+    useToken
+  }
+}

--- a/src/lib/helpers/authorize.js
+++ b/src/lib/helpers/authorize.js
@@ -1,33 +1,42 @@
-import { base64URLEncode, sha256 } from "./sha256-base64-url-encode"
-import createCodeVerifier from './create-code-verifier'
-import hashed from './hashed'
-import getEncodedVerifierKey from './getEncodedVerifierKey'
+"use strict";
 
-export default function authorize({
-  provider,
-  clientId,
-  scopes,
-  storage = sessionStorage
-}) {
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = authorize;
 
-  const encodedVerifier = base64URLEncode(createCodeVerifier())
-  storage.setItem(
-    getEncodedVerifierKey(clientId),
-    encodedVerifier
-  )
+var _sha256Base64UrlEncode = require("./sha256-base64-url-encode");
 
-  const query = {
+var _createCodeVerifier = _interopRequireDefault(require("./create-code-verifier"));
+
+var _hashed = _interopRequireDefault(require("./hashed"));
+
+var _getEncodedVerifierKey = _interopRequireDefault(require("./getEncodedVerifierKey"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function authorize(_ref) {
+  var provider = _ref.provider,
+      clientId = _ref.clientId,
+      scopes = _ref.scopes,
+      redirectUri = _ref.redirectUri || window.location,
+      _ref$storage = _ref.storage,
+      storage = _ref$storage === void 0 ? sessionStorage : _ref$storage;
+  var encodedVerifier = (0, _sha256Base64UrlEncode.base64URLEncode)((0, _createCodeVerifier.default)());
+  storage.setItem((0, _getEncodedVerifierKey.default)(clientId), encodedVerifier);
+  var query = {
     client_id: clientId,
     response_type: 'code',
-    redirect_uri: window.location,
-    code_challenge: base64URLEncode(sha256(encodedVerifier)),
-    code_challenge_method: 'S256',
-  }
+    redirect_uri: redirectUri,
+    code_challenge: (0, _sha256Base64UrlEncode.base64URLEncode)((0, _sha256Base64UrlEncode.sha256)(encodedVerifier)),
+    code_challenge_method: 'S256'
+  };
 
   if (scopes && scopes.length > 0) {
-    query.scope = scopes.join(' ')
+    query.scope = scopes.join(' ');
   }
-  
-  const url = `${ provider }/authorize?${ hashed(query) }`
-  window.location.replace(url)
+
+  var url = "".concat(provider, "/authorize?").concat((0, _hashed.default)(query));
+  window.location.replace(url);
 }
+//# sourceMappingURL=authorize.js.map

--- a/src/lib/helpers/authorize.js
+++ b/src/lib/helpers/authorize.js
@@ -1,42 +1,34 @@
-"use strict";
+import { base64URLEncode, sha256 } from "./sha256-base64-url-encode"
+import createCodeVerifier from './create-code-verifier'
+import hashed from './hashed'
+import getEncodedVerifierKey from './getEncodedVerifierKey'
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.default = authorize;
+export default function authorize({
+  provider,
+  clientId,
+  scopes,
+  storage = sessionStorage,
+  redirectUri,
+}) {
 
-var _sha256Base64UrlEncode = require("./sha256-base64-url-encode");
+  const encodedVerifier = base64URLEncode(createCodeVerifier())
+  storage.setItem(
+    getEncodedVerifierKey(clientId),
+    encodedVerifier
+  )
 
-var _createCodeVerifier = _interopRequireDefault(require("./create-code-verifier"));
-
-var _hashed = _interopRequireDefault(require("./hashed"));
-
-var _getEncodedVerifierKey = _interopRequireDefault(require("./getEncodedVerifierKey"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function authorize(_ref) {
-  var provider = _ref.provider,
-      clientId = _ref.clientId,
-      scopes = _ref.scopes,
-      redirectUri = _ref.redirectUri || window.location,
-      _ref$storage = _ref.storage,
-      storage = _ref$storage === void 0 ? sessionStorage : _ref$storage;
-  var encodedVerifier = (0, _sha256Base64UrlEncode.base64URLEncode)((0, _createCodeVerifier.default)());
-  storage.setItem((0, _getEncodedVerifierKey.default)(clientId), encodedVerifier);
-  var query = {
+  const query = {
     client_id: clientId,
     response_type: 'code',
-    redirect_uri: redirectUri,
-    code_challenge: (0, _sha256Base64UrlEncode.base64URLEncode)((0, _sha256Base64UrlEncode.sha256)(encodedVerifier)),
-    code_challenge_method: 'S256'
-  };
-
-  if (scopes && scopes.length > 0) {
-    query.scope = scopes.join(' ');
+    redirect_uri: redirectUri || window.location,
+    code_challenge: base64URLEncode(sha256(encodedVerifier)),
+    code_challenge_method: 'S256',
   }
 
-  var url = "".concat(provider, "/authorize?").concat((0, _hashed.default)(query));
-  window.location.replace(url);
+  if (scopes && scopes.length > 0) {
+    query.scope = scopes.join(' ')
+  }
+  
+  const url = `${ provider }/authorize?${ hashed(query) }`
+  window.location.replace(url)
 }
-//# sourceMappingURL=authorize.js.map

--- a/src/lib/helpers/fetchToken.js
+++ b/src/lib/helpers/fetchToken.js
@@ -1,37 +1,61 @@
-export const fetchToken = ({ clientId, clientSecret, code, verifier, tokenEndpoint, fetch = window.fetch }) => {
-  const payload = {
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.fetchToken = void 0;
+
+var fetchToken = function fetchToken(_ref) {
+  var clientId = _ref.clientId,
+      clientSecret = _ref.clientSecret,
+      code = _ref.code,
+      verifier = _ref.verifier,
+      tokenEndpoint = _ref.tokenEndpoint,
+      _ref$fetch = _ref.fetch,
+      redirectUri = _ref.redirectUri || window.location,
+      useUrlEncodedForm = _ref.useUrlEncodedForm,
+      fetch = _ref$fetch === void 0 ? window.fetch : _ref$fetch;
+  var payload = {
     client_id: clientId,
-    code,
+    code: code,
     grant_type: 'authorization_code',
+    redirect_uri: redirectUri,
     code_verifier: verifier
   };
+
+  var body = useUrlEncodedForm ? Object.keys(payload).map(key => key + '=' + payload[key]).join('&') : JSON.stringify(payload);
+
   if (clientSecret) {
-    payload.client_secret = clientSecret
+    payload.client_secret = clientSecret;
   }
+
   return fetch(tokenEndpoint, {
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': useUrlEncodedForm ? 'application/x-www-form-urlencoded' : 'application/json'
     },
     method: 'POST',
-    body: JSON.stringify(payload)
-  })
-    .then(r => {
-      if (!r.ok) {
-        throw new Error(`Token response not ok, status is ${r.status}, check the react-u5auth configuration (wrong provider or token endpoint?)`);
-      }
-      return r.json();
-    })
-    .then(token => {
-      const { expires_in } = token;
-      if (expires_in && Number.isFinite(expires_in)) {
-        const slackSeconds = 10;
-        // add 'expires_at', with the given slack
-        token.expires_at = new Date(new Date().getTime() + expires_in * 1000 - (slackSeconds * 1000));
-      }
-      return token;
-    })
-    .catch(err => {
-      console.error('ERR (fetch)', err);
-      throw err;
-    });
-}
+    body: body
+  }).then(function (r) {
+    if (!r.ok) {
+      throw new Error("Token response not ok, status is ".concat(r.status, ", check the react-u5auth configuration (wrong provider or token endpoint?)"));
+    }
+
+    return r.json();
+  }).then(function (token) {
+    var expires_in = token.expires_in;
+
+    if (expires_in && Number.isFinite(expires_in)) {
+      var slackSeconds = 10; // add 'expires_at', with the given slack
+
+      token.expires_at = new Date(new Date().getTime() + expires_in * 1000 - slackSeconds * 1000);
+    }
+
+    return token;
+  }).catch(function (err) {
+    console.error('ERR (fetch)', err);
+    throw err;
+  });
+};
+
+exports.fetchToken = fetchToken;
+//# sourceMappingURL=fetchToken.js.map

--- a/src/lib/helpers/fetchToken.js
+++ b/src/lib/helpers/fetchToken.js
@@ -1,61 +1,42 @@
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports.fetchToken = void 0;
-
-var fetchToken = function fetchToken(_ref) {
-  var clientId = _ref.clientId,
-      clientSecret = _ref.clientSecret,
-      code = _ref.code,
-      verifier = _ref.verifier,
-      tokenEndpoint = _ref.tokenEndpoint,
-      _ref$fetch = _ref.fetch,
-      redirectUri = _ref.redirectUri || window.location,
-      useUrlEncodedForm = _ref.useUrlEncodedForm,
-      fetch = _ref$fetch === void 0 ? window.fetch : _ref$fetch;
-  var payload = {
+export const fetchToken = ({ clientId, clientSecret, code, verifier, tokenEndpoint, fetch = window.fetch }) => {
+  const payload = {
     client_id: clientId,
-    code: code,
+    code,
     grant_type: 'authorization_code',
-    redirect_uri: redirectUri,
-    code_verifier: verifier
+    code_verifier: verifier,
+    redirectUri,
+    useUrlEncodedForm,
   };
+  if (clientSecret) {
+    payload.client_secret = clientSecret
+  }
 
   var body = useUrlEncodedForm ? Object.keys(payload).map(key => key + '=' + payload[key]).join('&') : JSON.stringify(payload);
-
-  if (clientSecret) {
-    payload.client_secret = clientSecret;
-  }
 
   return fetch(tokenEndpoint, {
     headers: {
       'Content-Type': useUrlEncodedForm ? 'application/x-www-form-urlencoded' : 'application/json'
     },
     method: 'POST',
-    body: body
-  }).then(function (r) {
-    if (!r.ok) {
-      throw new Error("Token response not ok, status is ".concat(r.status, ", check the react-u5auth configuration (wrong provider or token endpoint?)"));
-    }
-
-    return r.json();
-  }).then(function (token) {
-    var expires_in = token.expires_in;
-
-    if (expires_in && Number.isFinite(expires_in)) {
-      var slackSeconds = 10; // add 'expires_at', with the given slack
-
-      token.expires_at = new Date(new Date().getTime() + expires_in * 1000 - slackSeconds * 1000);
-    }
-
-    return token;
-  }).catch(function (err) {
-    console.error('ERR (fetch)', err);
-    throw err;
-  });
-};
-
-exports.fetchToken = fetchToken;
-//# sourceMappingURL=fetchToken.js.map
+    body: JSON.stringify(body)
+  })
+    .then(r => {
+      if (!r.ok) {
+        throw new Error(`Token response not ok, status is ${r.status}, check the react-u5auth configuration (wrong provider or token endpoint?)`);
+      }
+      return r.json();
+    })
+    .then(token => {
+      const { expires_in } = token;
+      if (expires_in && Number.isFinite(expires_in)) {
+        const slackSeconds = 10;
+        // add 'expires_at', with the given slack
+        token.expires_at = new Date(new Date().getTime() + expires_in * 1000 - (slackSeconds * 1000));
+      }
+      return token;
+    })
+    .catch(err => {
+      console.error('ERR (fetch)', err);
+      throw err;
+    });
+}


### PR DESCRIPTION
Adding so flexibility for setting the 'Return Uri' when the default window.location is not working. a simple trailing slash may cause failure when requesting a token.

Added the possibility to use 'application/x-www-form-urlencoded' in stead of 'application/json'. Aws requires this for correct payload, see: https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html

And added the 'RedirectUri' to the fetchToken payload, also required by Aws, but I do not know if this breaks it for non Aws token services.

I have never done anything in JavaScript, I have C# as a background. So let me know if I broke any rules.

Regards,

Remco Bosman